### PR TITLE
Dev

### DIFF
--- a/public/YukiPrompt.txt
+++ b/public/YukiPrompt.txt
@@ -1,11 +1,6 @@
 
 Kamu adalah Yuki-chan, asisten belajar yang ramah dan santai. Fokus utamamu adalah membantu user dalam belajar bahasa Jepang, mengenal budaya Jepang, serta tempat-tempat menarik di Jepang.
 
-Gunakan kata ganti "Yuki" secara natural, misalnya:  
-- "Yuki bisa bantu..."  
-- "Yuki gak tahu..."  
-- "Yuki cuman bisa..."
-
 Jawabanmu harus singkat, langsung ke poin, dan gampang dimengerti. Jangan pakai kalimat penutup seperti "Ada pertanyaan lain?" atau ajakan lainnya.
 
 Pakai emoji kalau memang cocok banget, tapi jangan terlalu sering supaya isi jawaban tetap jelas.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "../configs/firebase-config";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import DictionaryService from "../services/DictionaryService";
 import NoteService from "../services/NoteService";
 import { useTheme } from "../contexts/ThemeContext";
@@ -69,24 +70,25 @@ export default function Home() {
         {/* Stats Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {[
-            { title: "📝 Active Notes", value: noteCount },
-            { title: "📚 Active Cards", value: flashcardCount },
+            { title: "📝 Active Notes", value: noteCount, link: "/note" },
+            { title: "📚 Active Cards", value: flashcardCount, link: "/dictionary" },
           ].map((stat, index) => (
-            <motion.div
-              key={index}
-              whileHover={{ scale: 1.05 }}
-              transition={{ type: "spring", stiffness: 300 }}
-              className={`rounded-xl p-6 border transition-colors ${
-                isLightMode 
-                  ? 'bg-white border-blue-200 hover:border-blue-400' 
-                  : 'bg-gray-800 border-[#64E9EE]/20 hover:border-[#64E9EE]/40'
-              }`}
-            >
-              <h3 className={`text-lg font-semibold mb-2 ${isLightMode ? 'text-blue-600' : 'text-[#13AAFB]'}`}>
-                {stat.title}
-              </h3>
-              <p className={`text-3xl font-bold ${isLightMode ? 'text-blue-700' : 'text-[#64E9EE]'}`}>{stat.value}</p>
-            </motion.div>
+            <Link key={index} to={stat.link} className="block">
+              <motion.div
+                whileHover={{ scale: 1.05 }}
+                transition={{ type: "spring", stiffness: 300 }}
+                className={`rounded-xl p-6 border transition-colors cursor-pointer ${
+                  isLightMode 
+                    ? 'bg-white border-blue-200 hover:border-blue-400' 
+                    : 'bg-gray-800 border-[#64E9EE]/20 hover:border-[#64E9EE]/40'
+                }`}
+              >
+                <h3 className={`text-lg font-semibold mb-2 ${isLightMode ? 'text-blue-600' : 'text-[#13AAFB]'}`}>
+                  {stat.title}
+                </h3>
+                <p className={`text-3xl font-bold ${isLightMode ? 'text-blue-700' : 'text-[#64E9EE]'}`}>{stat.value}</p>
+              </motion.div>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/services/DictionaryService.tsx
+++ b/src/services/DictionaryService.tsx
@@ -20,7 +20,7 @@ interface Dictionary {
   kategori: string;
 }
 
-const validCategories = ["Kata benda", "Kata sifat", "Slang", "Bisnis", "Umum"];
+const validCategories = ["Kata benda", "Kata kerja", "Kata sifat", "Slang", "Bisnis", "Umum"];
 
 class DictionaryService {
   private getUserDictionariesRef() {


### PR DESCRIPTION
This pull request includes updates to improve navigation in the `Home` page, enhance user experience, and refine content in the `DictionaryService` and `YukiPrompt.txt`. The most important changes include adding links to stats on the `Home` page, updating valid categories in the dictionary service, and refining Yuki's tone and response style.

### Enhancements to navigation and user experience:
* [`src/pages/Home.tsx`](diffhunk://#diff-e41191ca0fedc3d7c9cfce4db24a281797128fbd57681267d583ba9e01069a0eR5): Added the `Link` component from `react-router-dom` to enable navigation from stats cards to their respective pages (`/note` for notes and `/dictionary` for flashcards). Updated the stats grid to include clickable links for better user interaction. [[1]](diffhunk://#diff-e41191ca0fedc3d7c9cfce4db24a281797128fbd57681267d583ba9e01069a0eR5) [[2]](diffhunk://#diff-e41191ca0fedc3d7c9cfce4db24a281797128fbd57681267d583ba9e01069a0eL72-R80) [[3]](diffhunk://#diff-e41191ca0fedc3d7c9cfce4db24a281797128fbd57681267d583ba9e01069a0eR91)

### Refinements to dictionary service:
* [`src/services/DictionaryService.tsx`](diffhunk://#diff-fdd856d38823252a0b2146dadce33164b4b427bcd004f31ee2b84a00aa9408aeL23-R23): Expanded the list of valid categories by adding "Kata kerja" to better support verb entries in the dictionary.

### Updates to YukiPrompt.txt:
* [`public/YukiPrompt.txt`](diffhunk://#diff-8f54d28082f3a5fefbe2a3d1d95344322941f05cfb008e23478c51103bd09f8bL4-L8): Removed examples of natural usage of "Yuki" to simplify the prompt and maintain focus on concise, clear answers.